### PR TITLE
Only target the direct li children

### DIFF
--- a/src/slippry.js
+++ b/src/slippry.js
@@ -653,7 +653,7 @@
     init = function () {
       var first;
       slip.settings = $.extend({}, defaults, options);
-      slip.vars.slides = $(slip.settings.elements, el);
+      slip.vars.slides = $(el).children.(slip.settings.elements);
       slip.vars.count = slip.vars.slides.length;
       if (slip.settings.useCSS) { // deactivate css transitions on unsupported browsers
         if (!supports('transition')) {


### PR DESCRIPTION
This allows for content with li's to be appropriately measured in height. downside is only direct children of the main el can be slides. I think it's worth it.