### PR TITLE
Update slippry.js for compatibility with jQuery 1.8 and up

### DIFF
--- a/src/slippry.js
+++ b/src/slippry.js
@@ -214,7 +214,7 @@
     getFillerProportions = function ($slide) {
       var width, height;
       if (($('img', $slide).attr("src") !== undefined)) {
-        $("<img />").load(function () {
+        $("<img />").on("load", function () {
           width = $slide.width();
           height = $slide.height();
           setFillerProportions(width, height);
@@ -601,7 +601,7 @@
           }
         }).each(function () {
           if (this.complete) {
-            $(this).load();
+            start();
           }
         });
       });


### PR DESCRIPTION
Changed first .load(function()...) to .on("load", function()...) for the newer jQuery versions.
Removed the second .load(), no idea what that did, but changed it to start()