### PR TITLE
Use getBoundingClientRect for filler dimensions

### DIFF
--- a/src/slippry.js
+++ b/src/slippry.js
@@ -212,16 +212,18 @@
 
     // gets the aspect ratio of the filler element
     getFillerProportions = function ($slide) {
-      var width, height;
+      var width, height, rect;
       if (($('img', $slide).attr("src") !== undefined)) {
         $("<img />").on("load", function () {
-          width = $slide.width();
-          height = $slide.height();
+          rect = $slide[0].getBoundingClientRect();
+          width = rect.width;
+          height = rect.height;
           setFillerProportions(width, height);
         }).attr("src", $('img', $slide).attr("src"));
       } else {
-        width = $slide.width();
-        height = $slide.height();
+        rect = $slide[0].getBoundingClientRect();
+        width = rect.width;
+        height = rect.height;
         setFillerProportions(width, height);
       }
     };


### PR DESCRIPTION
I had issues trying to get the plugin to work with some basic and simple HTML (no images). The ratio for the filler proportions were miscalculated because the target elements had some padding and margin.

I was able to sort this by replacing all the `.width()` and `.height()` calls from `getFillerProportions` to the more reliable [getBoundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).

This worked pretty well for me and if you want to merge the PR, here you have it 😀