### PR TITLE
Fixed Mootools Conflics

### DIFF
--- a/src/slippry.js
+++ b/src/slippry.js
@@ -603,10 +603,10 @@
           if (this.complete) {
             $(this).trigger('loads');
           }else{
-			$(this).one('load',function(){
-				$(this).trigger('loads');
-			})
-		  }
+            $(this).one('load',function(){
+              $(this).trigger('loads');
+            })
+          }
         });
       });
     };

--- a/src/slippry.js
+++ b/src/slippry.js
@@ -214,7 +214,7 @@
     getFillerProportions = function ($slide) {
       var width, height;
       if (($('img', $slide).attr("src") !== undefined)) {
-        $("<img />").on("load", function () {
+        $("<img />").on("load loads", function () {
           width = $slide.width();
           height = $slide.height();
           setFillerProportions(width, height);
@@ -595,13 +595,13 @@
       }
       loop = 0;
       elements.each(function () {
-        $(this).one('load error', function () {
+        $(this).one('loads error', function () {
           if (++loop === count) {
             start();
           }
         }).each(function () {
           if (this.complete) {
-            $(this).trigger('load');
+            $(this).trigger('loads');
           }
         });
       });

--- a/src/slippry.js
+++ b/src/slippry.js
@@ -602,7 +602,11 @@
         }).each(function () {
           if (this.complete) {
             $(this).trigger('loads');
-          }
+          }else{
+			$(this).one('load',function(){
+				$(this).trigger('loads');
+			})
+		  }
         });
       });
     };


### PR DESCRIPTION
Hey there,

I noticed a bug which doesn't allow Slippry to coexist with the Mootools library. Especially with either `mootools-core.js` or `mootools-more.js`. However I needed both Slippry and Mootools to be on the same page in one of my projects so I decided to create a pull request which reflects my changes which were necessary to get it to work correctly. The problem originates in the `load` event which is triggered on preload of the slider images. This somehow causes serious issues with Mootools. One important reference I have to make is an other pull request of another repository which pointed me in the right direction [#53 - Collage Plus](https://github.com/ed-lea/jquery-collagePlus/pull/52).

Basically I simply replaced the default `load` event with a custom one called `loads` (s for slippery). With the proposed changes it now works without any issues. 

Edit: Updated image load `trigger` to react on cached and non cached page load.